### PR TITLE
Modify string and character literals to use codepage, fix TNum bug

### DIFF
--- a/Codepage.hs
+++ b/Codepage.hs
@@ -46,11 +46,14 @@ aliases = [('¤', "cur"), ('½', "hlf"), ('↕', "ud"),  ('↑', "up"),  ('↓',
 getCommands :: [Word8] -> String
 getCommands = map $ (codepage !!) . fromEnum
 
+-- Get the position of a character in the code page
+findByte :: Char -> Int
+findByte byte | Just ix <- elemIndex byte codepage = ix
+              | otherwise = error "Bad byte"
+
 -- Convert a program to list of bytes
 getBytes :: String -> [Word8]
 getBytes = map $ toEnum . findByte
-  where findByte byte | Just ix <- elemIndex byte codepage = ix
-                      | otherwise = error "Bad byte"
 
 -- Get the alias of a character
 getAlias :: Char -> String

--- a/Parser.hs
+++ b/Parser.hs
@@ -6,6 +6,7 @@ import Expr
 import Builtins
 import PrattParser
 import DecompressString
+import Codepage
 import Text.Parsec
 import Text.Parsec.Char
 import Control.Monad (forM, foldM)
@@ -223,7 +224,9 @@ float = do
 character :: Parser (Exp [Lit Scheme])
 character = do
   quote <- char '\''
-  c <- anyChar
+  coded <- anyChar
+  let c :: Char
+      c = toEnum $ findByte coded
   return $ ELit [Value (show c) $ Scheme [] $ CType [] $ TConc TChar]
 
 -- Parse a string
@@ -240,11 +243,11 @@ str = do
       maybeEscape <- optionMaybe $ char '\\' >> anyChar
       case maybeEscape of
         Nothing -> return plainText
-        Just c -> do plainText2 <- content; return $ plainText++c:plainText2
+        Just c -> do plainText2 <- content; return $ plainText ++ toEnum (findByte c) : plainText2
     decode '¶' = '\n'
     decode '¨' = '"'
     decode '¦' = '\\'
-    decode  c  =  c
+    decode  c  = toEnum $ findByte c
 
 -- Parse a compressed string
 comprstr :: Parser (Exp [Lit Scheme])

--- a/defs.hs
+++ b/defs.hs
@@ -174,7 +174,7 @@ instance Floating TNum where
 
 instance RealFrac TNum where
   properFraction a@(_ :% 0) = (0, a)
-  properFraction (p :% q) | r <- div p q = (fromInteger r, (p - r) :% q)
+  properFraction (p :% q) | r <- quot p q = (fromInteger r, (p - r) :% q)
   properFraction (TDbl a) | (n, r) <- properFraction a = (n, TDbl r)
 
 -- Class of all Husk types (used for defaulting)


### PR DESCRIPTION
I've only found two answers (as of September 7, the last data dump) that the change would affect, and both are currently invalid:

- https://codegolf.stackexchange.com/a/154298: This answer is currently invalid according to the rules of the challenge, but the change would make it valid as is.

- https://codegolf.stackexchange.com/a/167811: This answer is currently invalid in Husk's codepage (in `-u` mode it does not check for compliance), making it 26 bytes in UTF-8. With the change, `zoΣ~+R;'¦oJR2'¦msNU¡Ẋ+` would be valid and retain the original 22 bytes.